### PR TITLE
fix: comma after fullstop in Hello Rida section

### DIFF
--- a/components/MetaData.tsx
+++ b/components/MetaData.tsx
@@ -11,7 +11,7 @@ interface MetaDataProps {
 
 const MetaData: React.VFC<MetaDataProps> = ({
   title = "Rida F'kih — Developer & Designer",
-  description = "I'm a Canadian software developer based in Calgary, Alta., I learned to code make my life a little easier. I currently work at MaxRewards as a reverse engineer & fullstack developer.",
+  description = "I'm a Canadian software developer based in Calgary, Alta. I learned to code make my life a little easier. I currently work at MaxRewards as a reverse engineer & fullstack developer.",
   bannerUrl = getCurrentUrl("/meta-preview.png"),
   currentUrl,
 }) => {


### PR DESCRIPTION
# Problem
![image](https://user-images.githubusercontent.com/39814328/226220063-adb73d12-9c01-4257-8e03-3423f4862a08.png)

# Solution
![image](https://user-images.githubusercontent.com/39814328/226220104-ecfe83a4-a512-49ef-97ec-97690af750e9.png)

# TLDR
fixed typo with additional comma after fullstop in Hello Rida section.

# Additional information
none.